### PR TITLE
chore(eslint): stop extending from unexisting plugin - prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,5 @@ module.exports = {
     ecmaVersion: 8,
   },
   root: true,
-  extends: ["eslint:recommended", "plugin:prettier/recommended"],
+  extends: "eslint:recommended",
 };


### PR DESCRIPTION
Currently, the this project's ESLint config extends from`"plugin:prettier/recommended"`. However, the `eslint-plugin-prettier` package is not a dependency of the project and running ESLint throws an error. This PR removes prettier from the ESLint configuration. Note that users can still use `prettier` for formatting by running `npx prettier .` or using an IDE, such as VSCode with the `prettier` extension.